### PR TITLE
Add a fallback credential for Linux.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
@@ -1180,6 +1181,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8ed1639f4b56ec6f31d007ff66ce4a13099dce5a9995d48368a30d62bf04bd"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.22",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2425,6 +2461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2536,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4368,6 +4411,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5313,6 +5384,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,26 +1247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
-name = "data-encoding-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
-dependencies = [
- "data-encoding",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "data-url"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,9 +5294,9 @@ dependencies = [
  "async-stream",
  "async-trait",
  "authtea",
+ "base64",
  "chrono",
  "data-encoding",
- "data-encoding-macro",
  "enum_dispatch",
  "futures-core",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ chrono = { version = "0.4", default-features = false, features = [
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
 log = "0.4"
+base64 = "0.21"
 
 futures-core = "0.3"
 futures-util = "0.3"
@@ -61,6 +62,7 @@ mac_address = { version = "2", package = "mac_address2" }
 
 serde = "1"
 serde_json = "1"
+serde_with = "3"
 
 tokio = "1"
 tokio-stream = "0.1"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ sudo systemctl start tunet@foo
 ``` bash
 $ tunet deletecred
 ```
+注意：由于 Linux 的限制，目前没有找到合适的持续化密码保存方法，因此会直接明文存储。
 
 ## 网络状态
 针对不同平台使用平台特定的方式尝试获得当前的网络连接方式，如果是无线网连接还会获取 SSID。

--- a/tunet-helper/Cargo.toml
+++ b/tunet-helper/Cargo.toml
@@ -21,7 +21,7 @@ md-5 = "0.10"
 sha-1 = "0.10"
 hmac = "0.12"
 data-encoding = "2"
-data-encoding-macro = "0.1"
+base64 = { workspace = true }
 serde_json = { workspace = true }
 select = "0.6"
 chrono = { workspace = true }

--- a/tunet-helper/src/auth.rs
+++ b/tunet-helper/src/auth.rs
@@ -1,7 +1,11 @@
 use crate::*;
 use authtea::AuthTea;
-use data_encoding::{Encoding, HEXLOWER};
-use data_encoding_macro::new_encoding;
+use base64::{
+    alphabet::Alphabet,
+    engine::{general_purpose::PAD, GeneralPurpose},
+    Engine,
+};
+use data_encoding::HEXLOWER;
 use hmac::{Hmac, Mac};
 use md5::Md5;
 use once_cell::sync::Lazy;
@@ -17,10 +21,11 @@ pub struct AuthConnect<U: AuthConnectUri + Send + Sync> {
     _p: PhantomData<U>,
 }
 
-const AUTH_BASE64: Encoding = new_encoding! {
-    symbols: "LVoJPiCN2R8G90yg+hmFHuacZ1OWMnrsSTXkYpUq/3dlbfKwv6xztjI7DeBE45QA",
-    padding: '=',
-};
+pub static AUTH_BASE64: Lazy<GeneralPurpose> = Lazy::new(|| {
+    let alphabet =
+        Alphabet::new("LVoJPiCN2R8G90yg+hmFHuacZ1OWMnrsSTXkYpUq/3dlbfKwv6xztjI7DeBE45QA").unwrap();
+    GeneralPurpose::new(&alphabet, PAD)
+});
 
 static REDIRECT_URI: &str = "http://www.tsinghua.edu.cn/";
 

--- a/tunet-settings/Cargo.toml
+++ b/tunet-settings/Cargo.toml
@@ -13,4 +13,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 dirs = { workspace = true }
 rpassword = "7"
-serde_with = { version = "3", features = ["base64"] }
+serde_with = { workspace = true, features = ["base64"] }

--- a/tunet-settings/Cargo.toml
+++ b/tunet-settings/Cargo.toml
@@ -13,3 +13,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 dirs = { workspace = true }
 rpassword = "7"
+serde_with = { version = "3", features = ["base64"] }

--- a/tunet-settings/src/key_fallback.rs
+++ b/tunet-settings/src/key_fallback.rs
@@ -1,0 +1,75 @@
+use crate::{SettingsError, SettingsResult};
+use dirs::config_dir;
+use keyring::{credential::CredentialApi, Error, Result};
+use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+pub struct KeyFallback {
+    service_path: PathBuf,
+    user: String,
+}
+
+impl KeyFallback {
+    pub fn new(service: &str, user: &str) -> SettingsResult<Self> {
+        let mut service_path = config_dir().ok_or(SettingsError::ConfigDirNotFound)?;
+        service_path.push(service);
+        service_path.push("cred");
+        service_path.set_extension("json");
+        Ok(Self {
+            service_path,
+            user: user.into(),
+        })
+    }
+
+    fn read_cred_file(&self) -> Result<HashMap<String, Password>> {
+        if self.service_path.exists() {
+            let f = File::open(&self.service_path).map_err(|e| Error::NoStorageAccess(e.into()))?;
+            let reader = BufReader::new(f);
+            serde_json::from_reader(reader).map_err(|e| Error::PlatformFailure(e.into()))
+        } else {
+            Ok(HashMap::new())
+        }
+    }
+
+    fn save_cred_file(&self, map: &HashMap<String, Password>) -> Result<()> {
+        let f = File::create(&self.service_path).map_err(|e| Error::NoStorageAccess(e.into()))?;
+        let writer = BufWriter::new(f);
+        serde_json::to_writer(writer, map).map_err(|e| Error::PlatformFailure(e.into()))
+    }
+}
+
+impl CredentialApi for KeyFallback {
+    fn set_password(&self, password: &str) -> Result<()> {
+        let mut cred = self.read_cred_file()?;
+        cred.insert(self.user.clone(), Password(password.as_bytes().to_vec()));
+        self.save_cred_file(&cred)
+    }
+
+    fn get_password(&self) -> Result<String> {
+        let mut cred = self.read_cred_file()?;
+        cred.remove(&self.user)
+            .ok_or(Error::NoEntry)
+            .and_then(|p| String::from_utf8(p.0).map_err(|e| Error::BadEncoding(e.into_bytes())))
+    }
+
+    fn delete_password(&self) -> Result<()> {
+        let mut cred = self.read_cred_file()?;
+        cred.remove(&self.user);
+        self.save_cred_file(&cred)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+struct Password(#[serde_as(as = "Base64")] pub Vec<u8>);


### PR DESCRIPTION
Fixes #71 

- [x] A fallback credential.
- [ ] Use custom base64 alphabet.
- [x] Use the same base64 lib in both crates.